### PR TITLE
[Submission - Valentin Najean] EPL match data fetching script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+
+# Environments
+.env
+.venv/
+venv/
+
+# Output files
+#*.csv  in this case I want to submit the outputs
+*.json

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ API account name: testing.data999@gmail.com
 API token information:
 
 Please modify your client to use a HTTP header named "X-Auth-Token" with the underneath personal token as value. Your token: 12abfbaacdab48bc8948ed6061925e1f
+
+# notes
+While using the API I noticed that the above token does not give me access to seasons prior to 2023.
+So for this test instead of querying 2020-2023, I only queried 2023-2024.
+
+- pytest.ini used to fix some issues caused by a space in my folder names
+- the API was mocked in the unit tests
+- example.py is used to get query_example.json which gave me the API dictionnary format
+- Token stored in .env

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ While using the API I noticed that the above token does not give me access to se
 So for this test instead of querying 2020-2023, I only queried 2023-2024.
 
 - pytest.ini used to fix some issues caused by a space in my folder names
-- the API was mocked in the unit tests
+- Unit tests are provided in the tests/ folder
+- All external API calls are mocked for consistent, offline test run
 - example.py is used to get query_example.json which gave me the API dictionnary format
-- Token stored in .env
+- Token stored in .env (.gitignore)
+- example.py used to inspect the structure of the API response
+- Outputs: match_raw_data.csv and match_team_stats.csv
+- argparse used for CLI flexibility (--seasons) with default: --seasons 2023 2024 the only accessible seasons with this token.

--- a/example.py
+++ b/example.py
@@ -1,0 +1,15 @@
+import requests
+from dotenv import load_dotenv
+import os
+import json
+
+load_dotenv()
+API_TOKEN = os.getenv("API_TOKEN")
+headers = {'X-Auth-Token': API_TOKEN}
+
+response = requests.get("https://api.football-data.org/v4/competitions/PL/matches?season=2023", headers=headers)
+data = response.json()
+
+# Save the data to a JSON file to inspect the structure
+with open('query_example.json', 'w') as f:
+    json.dump(data, f, indent=4)

--- a/match_raw_data.csv
+++ b/match_raw_data.csv
@@ -1,0 +1,731 @@
+season,date,matchday,hometeam,awayteam,homeGoals,awayGoals,winner
+2023,2023-08-11,1,Burnley FC,Manchester City FC,0,3,AWAY_TEAM
+2023,2023-08-12,1,Arsenal FC,Nottingham Forest FC,2,1,HOME_TEAM
+2023,2023-08-12,1,AFC Bournemouth,West Ham United FC,1,1,DRAW
+2023,2023-08-12,1,Brighton & Hove Albion FC,Luton Town FC,4,1,HOME_TEAM
+2023,2023-08-12,1,Everton FC,Fulham FC,0,1,AWAY_TEAM
+2023,2023-08-12,1,Sheffield United FC,Crystal Palace FC,0,1,AWAY_TEAM
+2023,2023-08-12,1,Newcastle United FC,Aston Villa FC,5,1,HOME_TEAM
+2023,2023-08-13,1,Brentford FC,Tottenham Hotspur FC,2,2,DRAW
+2023,2023-08-13,1,Chelsea FC,Liverpool FC,1,1,DRAW
+2023,2023-08-14,1,Manchester United FC,Wolverhampton Wanderers FC,1,0,HOME_TEAM
+2023,2023-08-18,2,Nottingham Forest FC,Sheffield United FC,2,1,HOME_TEAM
+2023,2023-08-19,2,Fulham FC,Brentford FC,0,3,AWAY_TEAM
+2023,2023-08-19,2,Liverpool FC,AFC Bournemouth,3,1,HOME_TEAM
+2023,2023-08-19,2,Wolverhampton Wanderers FC,Brighton & Hove Albion FC,1,4,AWAY_TEAM
+2023,2023-08-19,2,Tottenham Hotspur FC,Manchester United FC,2,0,HOME_TEAM
+2023,2023-08-19,2,Manchester City FC,Newcastle United FC,1,0,HOME_TEAM
+2023,2023-08-20,2,Aston Villa FC,Everton FC,4,0,HOME_TEAM
+2023,2023-08-20,2,West Ham United FC,Chelsea FC,3,1,HOME_TEAM
+2023,2023-08-21,2,Crystal Palace FC,Arsenal FC,0,1,AWAY_TEAM
+2023,2023-08-25,3,Chelsea FC,Luton Town FC,3,0,HOME_TEAM
+2023,2023-08-26,3,AFC Bournemouth,Tottenham Hotspur FC,0,2,AWAY_TEAM
+2023,2023-08-26,3,Everton FC,Wolverhampton Wanderers FC,0,1,AWAY_TEAM
+2023,2023-08-26,3,Manchester United FC,Nottingham Forest FC,3,2,HOME_TEAM
+2023,2023-08-26,3,Arsenal FC,Fulham FC,2,2,DRAW
+2023,2023-08-26,3,Brentford FC,Crystal Palace FC,1,1,DRAW
+2023,2023-08-26,3,Brighton & Hove Albion FC,West Ham United FC,1,3,AWAY_TEAM
+2023,2023-08-27,3,Sheffield United FC,Manchester City FC,1,2,AWAY_TEAM
+2023,2023-08-27,3,Burnley FC,Aston Villa FC,1,3,AWAY_TEAM
+2023,2023-08-27,3,Newcastle United FC,Liverpool FC,1,2,AWAY_TEAM
+2023,2023-09-01,4,Luton Town FC,West Ham United FC,1,2,AWAY_TEAM
+2023,2023-09-02,4,Sheffield United FC,Everton FC,2,2,DRAW
+2023,2023-09-02,4,Brentford FC,AFC Bournemouth,2,2,DRAW
+2023,2023-09-02,4,Burnley FC,Tottenham Hotspur FC,2,5,AWAY_TEAM
+2023,2023-09-02,4,Chelsea FC,Nottingham Forest FC,0,1,AWAY_TEAM
+2023,2023-09-02,4,Manchester City FC,Fulham FC,5,1,HOME_TEAM
+2023,2023-09-02,4,Brighton & Hove Albion FC,Newcastle United FC,3,1,HOME_TEAM
+2023,2023-09-03,4,Crystal Palace FC,Wolverhampton Wanderers FC,3,2,HOME_TEAM
+2023,2023-09-03,4,Liverpool FC,Aston Villa FC,3,0,HOME_TEAM
+2023,2023-09-03,4,Arsenal FC,Manchester United FC,3,1,HOME_TEAM
+2023,2023-09-16,5,Wolverhampton Wanderers FC,Liverpool FC,1,3,AWAY_TEAM
+2023,2023-09-16,5,Aston Villa FC,Crystal Palace FC,3,1,HOME_TEAM
+2023,2023-09-16,5,Fulham FC,Luton Town FC,1,0,HOME_TEAM
+2023,2023-09-16,5,Manchester United FC,Brighton & Hove Albion FC,1,3,AWAY_TEAM
+2023,2023-09-16,5,Tottenham Hotspur FC,Sheffield United FC,2,1,HOME_TEAM
+2023,2023-09-16,5,West Ham United FC,Manchester City FC,1,3,AWAY_TEAM
+2023,2023-09-16,5,Newcastle United FC,Brentford FC,1,0,HOME_TEAM
+2023,2023-09-17,5,AFC Bournemouth,Chelsea FC,0,0,DRAW
+2023,2023-09-17,5,Everton FC,Arsenal FC,0,1,AWAY_TEAM
+2023,2023-09-18,5,Nottingham Forest FC,Burnley FC,1,1,DRAW
+2023,2023-09-23,6,Crystal Palace FC,Fulham FC,0,0,DRAW
+2023,2023-09-23,6,Luton Town FC,Wolverhampton Wanderers FC,1,1,DRAW
+2023,2023-09-23,6,Manchester City FC,Nottingham Forest FC,2,0,HOME_TEAM
+2023,2023-09-23,6,Brentford FC,Everton FC,1,3,AWAY_TEAM
+2023,2023-09-23,6,Burnley FC,Manchester United FC,0,1,AWAY_TEAM
+2023,2023-09-24,6,Arsenal FC,Tottenham Hotspur FC,2,2,DRAW
+2023,2023-09-24,6,Brighton & Hove Albion FC,AFC Bournemouth,3,1,HOME_TEAM
+2023,2023-09-24,6,Chelsea FC,Aston Villa FC,0,1,AWAY_TEAM
+2023,2023-09-24,6,Liverpool FC,West Ham United FC,3,1,HOME_TEAM
+2023,2023-09-24,6,Sheffield United FC,Newcastle United FC,0,8,AWAY_TEAM
+2023,2023-09-30,7,Aston Villa FC,Brighton & Hove Albion FC,6,1,HOME_TEAM
+2023,2023-09-30,7,AFC Bournemouth,Arsenal FC,0,4,AWAY_TEAM
+2023,2023-09-30,7,Everton FC,Luton Town FC,1,2,AWAY_TEAM
+2023,2023-09-30,7,Manchester United FC,Crystal Palace FC,0,1,AWAY_TEAM
+2023,2023-09-30,7,Newcastle United FC,Burnley FC,2,0,HOME_TEAM
+2023,2023-09-30,7,West Ham United FC,Sheffield United FC,2,0,HOME_TEAM
+2023,2023-09-30,7,Wolverhampton Wanderers FC,Manchester City FC,2,1,HOME_TEAM
+2023,2023-09-30,7,Tottenham Hotspur FC,Liverpool FC,2,1,HOME_TEAM
+2023,2023-10-01,7,Nottingham Forest FC,Brentford FC,1,1,DRAW
+2023,2023-10-02,7,Fulham FC,Chelsea FC,0,2,AWAY_TEAM
+2023,2023-10-03,2,Luton Town FC,Burnley FC,1,2,AWAY_TEAM
+2023,2023-10-07,8,Luton Town FC,Tottenham Hotspur FC,0,1,AWAY_TEAM
+2023,2023-10-07,8,Burnley FC,Chelsea FC,1,4,AWAY_TEAM
+2023,2023-10-07,8,Everton FC,AFC Bournemouth,3,0,HOME_TEAM
+2023,2023-10-07,8,Fulham FC,Sheffield United FC,3,1,HOME_TEAM
+2023,2023-10-07,8,Manchester United FC,Brentford FC,2,1,HOME_TEAM
+2023,2023-10-07,8,Crystal Palace FC,Nottingham Forest FC,0,0,DRAW
+2023,2023-10-08,8,Brighton & Hove Albion FC,Liverpool FC,2,2,DRAW
+2023,2023-10-08,8,West Ham United FC,Newcastle United FC,2,2,DRAW
+2023,2023-10-08,8,Wolverhampton Wanderers FC,Aston Villa FC,1,1,DRAW
+2023,2023-10-08,8,Arsenal FC,Manchester City FC,1,0,HOME_TEAM
+2023,2023-10-21,9,Liverpool FC,Everton FC,2,0,HOME_TEAM
+2023,2023-10-21,9,AFC Bournemouth,Wolverhampton Wanderers FC,1,2,AWAY_TEAM
+2023,2023-10-21,9,Brentford FC,Burnley FC,3,0,HOME_TEAM
+2023,2023-10-21,9,Manchester City FC,Brighton & Hove Albion FC,2,1,HOME_TEAM
+2023,2023-10-21,9,Newcastle United FC,Crystal Palace FC,4,0,HOME_TEAM
+2023,2023-10-21,9,Nottingham Forest FC,Luton Town FC,2,2,DRAW
+2023,2023-10-21,9,Chelsea FC,Arsenal FC,2,2,DRAW
+2023,2023-10-21,9,Sheffield United FC,Manchester United FC,1,2,AWAY_TEAM
+2023,2023-10-22,9,Aston Villa FC,West Ham United FC,4,1,HOME_TEAM
+2023,2023-10-23,9,Tottenham Hotspur FC,Fulham FC,2,0,HOME_TEAM
+2023,2023-10-27,10,Crystal Palace FC,Tottenham Hotspur FC,1,2,AWAY_TEAM
+2023,2023-10-28,10,Chelsea FC,Brentford FC,0,2,AWAY_TEAM
+2023,2023-10-28,10,AFC Bournemouth,Burnley FC,2,1,HOME_TEAM
+2023,2023-10-28,10,Arsenal FC,Sheffield United FC,5,0,HOME_TEAM
+2023,2023-10-28,10,Wolverhampton Wanderers FC,Newcastle United FC,2,2,DRAW
+2023,2023-10-29,10,West Ham United FC,Everton FC,0,1,AWAY_TEAM
+2023,2023-10-29,10,Aston Villa FC,Luton Town FC,3,1,HOME_TEAM
+2023,2023-10-29,10,Brighton & Hove Albion FC,Fulham FC,1,1,DRAW
+2023,2023-10-29,10,Liverpool FC,Nottingham Forest FC,3,0,HOME_TEAM
+2023,2023-10-29,10,Manchester United FC,Manchester City FC,0,3,AWAY_TEAM
+2023,2023-11-04,11,Fulham FC,Manchester United FC,0,1,AWAY_TEAM
+2023,2023-11-04,11,Brentford FC,West Ham United FC,3,2,HOME_TEAM
+2023,2023-11-04,11,Burnley FC,Crystal Palace FC,0,2,AWAY_TEAM
+2023,2023-11-04,11,Everton FC,Brighton & Hove Albion FC,1,1,DRAW
+2023,2023-11-04,11,Manchester City FC,AFC Bournemouth,6,1,HOME_TEAM
+2023,2023-11-04,11,Sheffield United FC,Wolverhampton Wanderers FC,2,1,HOME_TEAM
+2023,2023-11-04,11,Newcastle United FC,Arsenal FC,1,0,HOME_TEAM
+2023,2023-11-05,11,Nottingham Forest FC,Aston Villa FC,2,0,HOME_TEAM
+2023,2023-11-05,11,Luton Town FC,Liverpool FC,1,1,DRAW
+2023,2023-11-06,11,Tottenham Hotspur FC,Chelsea FC,1,4,AWAY_TEAM
+2023,2023-11-11,12,Wolverhampton Wanderers FC,Tottenham Hotspur FC,2,1,HOME_TEAM
+2023,2023-11-11,12,Arsenal FC,Burnley FC,3,1,HOME_TEAM
+2023,2023-11-11,12,Crystal Palace FC,Everton FC,2,3,AWAY_TEAM
+2023,2023-11-11,12,Manchester United FC,Luton Town FC,1,0,HOME_TEAM
+2023,2023-11-11,12,AFC Bournemouth,Newcastle United FC,2,0,HOME_TEAM
+2023,2023-11-12,12,Aston Villa FC,Fulham FC,3,1,HOME_TEAM
+2023,2023-11-12,12,Brighton & Hove Albion FC,Sheffield United FC,1,1,DRAW
+2023,2023-11-12,12,Liverpool FC,Brentford FC,3,0,HOME_TEAM
+2023,2023-11-12,12,West Ham United FC,Nottingham Forest FC,3,2,HOME_TEAM
+2023,2023-11-12,12,Chelsea FC,Manchester City FC,4,4,DRAW
+2023,2023-11-25,13,Manchester City FC,Liverpool FC,1,1,DRAW
+2023,2023-11-25,13,Burnley FC,West Ham United FC,1,2,AWAY_TEAM
+2023,2023-11-25,13,Luton Town FC,Crystal Palace FC,2,1,HOME_TEAM
+2023,2023-11-25,13,Newcastle United FC,Chelsea FC,4,1,HOME_TEAM
+2023,2023-11-25,13,Nottingham Forest FC,Brighton & Hove Albion FC,2,3,AWAY_TEAM
+2023,2023-11-25,13,Sheffield United FC,AFC Bournemouth,1,3,AWAY_TEAM
+2023,2023-11-25,13,Brentford FC,Arsenal FC,0,1,AWAY_TEAM
+2023,2023-11-26,13,Tottenham Hotspur FC,Aston Villa FC,1,2,AWAY_TEAM
+2023,2023-11-26,13,Everton FC,Manchester United FC,0,3,AWAY_TEAM
+2023,2023-11-27,13,Fulham FC,Wolverhampton Wanderers FC,3,2,HOME_TEAM
+2023,2023-12-02,14,Arsenal FC,Wolverhampton Wanderers FC,2,1,HOME_TEAM
+2023,2023-12-02,14,Brentford FC,Luton Town FC,3,1,HOME_TEAM
+2023,2023-12-02,14,Burnley FC,Sheffield United FC,5,0,HOME_TEAM
+2023,2023-12-02,14,Nottingham Forest FC,Everton FC,0,1,AWAY_TEAM
+2023,2023-12-02,14,Newcastle United FC,Manchester United FC,1,0,HOME_TEAM
+2023,2023-12-03,14,AFC Bournemouth,Aston Villa FC,2,2,DRAW
+2023,2023-12-03,14,Chelsea FC,Brighton & Hove Albion FC,3,2,HOME_TEAM
+2023,2023-12-03,14,Liverpool FC,Fulham FC,4,3,HOME_TEAM
+2023,2023-12-03,14,West Ham United FC,Crystal Palace FC,1,1,DRAW
+2023,2023-12-03,14,Manchester City FC,Tottenham Hotspur FC,3,3,DRAW
+2023,2023-12-05,15,Wolverhampton Wanderers FC,Burnley FC,1,0,HOME_TEAM
+2023,2023-12-05,15,Luton Town FC,Arsenal FC,3,4,AWAY_TEAM
+2023,2023-12-06,15,Brighton & Hove Albion FC,Brentford FC,2,1,HOME_TEAM
+2023,2023-12-06,15,Fulham FC,Nottingham Forest FC,5,0,HOME_TEAM
+2023,2023-12-06,15,Sheffield United FC,Liverpool FC,0,2,AWAY_TEAM
+2023,2023-12-06,15,Crystal Palace FC,AFC Bournemouth,0,2,AWAY_TEAM
+2023,2023-12-06,15,Aston Villa FC,Manchester City FC,1,0,HOME_TEAM
+2023,2023-12-06,15,Manchester United FC,Chelsea FC,2,1,HOME_TEAM
+2023,2023-12-07,15,Everton FC,Newcastle United FC,3,0,HOME_TEAM
+2023,2023-12-07,15,Tottenham Hotspur FC,West Ham United FC,1,2,AWAY_TEAM
+2023,2023-12-09,16,Crystal Palace FC,Liverpool FC,1,2,AWAY_TEAM
+2023,2023-12-09,16,Brighton & Hove Albion FC,Burnley FC,1,1,DRAW
+2023,2023-12-09,16,Manchester United FC,AFC Bournemouth,0,3,AWAY_TEAM
+2023,2023-12-09,16,Sheffield United FC,Brentford FC,1,0,HOME_TEAM
+2023,2023-12-09,16,Wolverhampton Wanderers FC,Nottingham Forest FC,1,1,DRAW
+2023,2023-12-09,16,Aston Villa FC,Arsenal FC,1,0,HOME_TEAM
+2023,2023-12-10,16,Everton FC,Chelsea FC,2,0,HOME_TEAM
+2023,2023-12-10,16,Fulham FC,West Ham United FC,5,0,HOME_TEAM
+2023,2023-12-10,16,Luton Town FC,Manchester City FC,1,2,AWAY_TEAM
+2023,2023-12-10,16,Tottenham Hotspur FC,Newcastle United FC,4,1,HOME_TEAM
+2023,2023-12-15,17,Nottingham Forest FC,Tottenham Hotspur FC,0,2,AWAY_TEAM
+2023,2023-12-16,17,Chelsea FC,Sheffield United FC,2,0,HOME_TEAM
+2023,2023-12-16,17,Manchester City FC,Crystal Palace FC,2,2,DRAW
+2023,2023-12-16,17,Newcastle United FC,Fulham FC,3,0,HOME_TEAM
+2023,2023-12-16,17,Burnley FC,Everton FC,0,2,AWAY_TEAM
+2023,2023-12-17,17,Arsenal FC,Brighton & Hove Albion FC,2,0,HOME_TEAM
+2023,2023-12-17,17,Brentford FC,Aston Villa FC,1,2,AWAY_TEAM
+2023,2023-12-17,17,West Ham United FC,Wolverhampton Wanderers FC,3,0,HOME_TEAM
+2023,2023-12-17,17,Liverpool FC,Manchester United FC,0,0,DRAW
+2023,2023-12-21,18,Crystal Palace FC,Brighton & Hove Albion FC,1,1,DRAW
+2023,2023-12-22,18,Aston Villa FC,Sheffield United FC,1,1,DRAW
+2023,2023-12-23,18,West Ham United FC,Manchester United FC,2,0,HOME_TEAM
+2023,2023-12-23,18,Fulham FC,Burnley FC,0,2,AWAY_TEAM
+2023,2023-12-23,18,Luton Town FC,Newcastle United FC,1,0,HOME_TEAM
+2023,2023-12-23,18,Nottingham Forest FC,AFC Bournemouth,2,3,AWAY_TEAM
+2023,2023-12-23,18,Tottenham Hotspur FC,Everton FC,2,1,HOME_TEAM
+2023,2023-12-23,18,Liverpool FC,Arsenal FC,1,1,DRAW
+2023,2023-12-24,18,Wolverhampton Wanderers FC,Chelsea FC,2,1,HOME_TEAM
+2023,2023-12-26,19,Newcastle United FC,Nottingham Forest FC,1,3,AWAY_TEAM
+2023,2023-12-26,19,AFC Bournemouth,Fulham FC,3,0,HOME_TEAM
+2023,2023-12-26,19,Sheffield United FC,Luton Town FC,2,3,AWAY_TEAM
+2023,2023-12-26,19,Burnley FC,Liverpool FC,0,2,AWAY_TEAM
+2023,2023-12-26,19,Manchester United FC,Aston Villa FC,3,2,HOME_TEAM
+2023,2023-12-27,19,Brentford FC,Wolverhampton Wanderers FC,1,4,AWAY_TEAM
+2023,2023-12-27,19,Chelsea FC,Crystal Palace FC,2,1,HOME_TEAM
+2023,2023-12-27,19,Everton FC,Manchester City FC,1,3,AWAY_TEAM
+2023,2023-12-28,19,Brighton & Hove Albion FC,Tottenham Hotspur FC,4,2,HOME_TEAM
+2023,2023-12-28,19,Arsenal FC,West Ham United FC,0,2,AWAY_TEAM
+2023,2023-12-30,20,Luton Town FC,Chelsea FC,2,3,AWAY_TEAM
+2023,2023-12-30,20,Aston Villa FC,Burnley FC,3,2,HOME_TEAM
+2023,2023-12-30,20,Crystal Palace FC,Brentford FC,3,1,HOME_TEAM
+2023,2023-12-30,20,Manchester City FC,Sheffield United FC,2,0,HOME_TEAM
+2023,2023-12-30,20,Wolverhampton Wanderers FC,Everton FC,3,0,HOME_TEAM
+2023,2023-12-30,20,Nottingham Forest FC,Manchester United FC,2,1,HOME_TEAM
+2023,2023-12-31,20,Fulham FC,Arsenal FC,2,1,HOME_TEAM
+2023,2023-12-31,20,Tottenham Hotspur FC,AFC Bournemouth,3,1,HOME_TEAM
+2023,2024-01-01,20,Liverpool FC,Newcastle United FC,4,2,HOME_TEAM
+2023,2024-01-02,20,West Ham United FC,Brighton & Hove Albion FC,0,0,DRAW
+2023,2024-01-12,21,Burnley FC,Luton Town FC,1,1,DRAW
+2023,2024-01-13,21,Chelsea FC,Fulham FC,1,0,HOME_TEAM
+2023,2024-01-13,21,Newcastle United FC,Manchester City FC,2,3,AWAY_TEAM
+2023,2024-01-14,21,Everton FC,Aston Villa FC,0,0,DRAW
+2023,2024-01-14,21,Manchester United FC,Tottenham Hotspur FC,2,2,DRAW
+2023,2024-01-20,21,Arsenal FC,Crystal Palace FC,5,0,HOME_TEAM
+2023,2024-01-20,21,Brentford FC,Nottingham Forest FC,3,2,HOME_TEAM
+2023,2024-01-21,21,Sheffield United FC,West Ham United FC,2,2,DRAW
+2023,2024-01-21,21,AFC Bournemouth,Liverpool FC,0,4,AWAY_TEAM
+2023,2024-01-22,21,Brighton & Hove Albion FC,Wolverhampton Wanderers FC,0,0,DRAW
+2023,2024-01-30,22,Nottingham Forest FC,Arsenal FC,1,2,AWAY_TEAM
+2023,2024-01-30,22,Luton Town FC,Brighton & Hove Albion FC,4,0,HOME_TEAM
+2023,2024-01-30,22,Fulham FC,Everton FC,0,0,DRAW
+2023,2024-01-30,22,Crystal Palace FC,Sheffield United FC,3,2,HOME_TEAM
+2023,2024-01-30,22,Aston Villa FC,Newcastle United FC,1,3,AWAY_TEAM
+2023,2024-01-31,22,Tottenham Hotspur FC,Brentford FC,3,2,HOME_TEAM
+2023,2024-01-31,22,Manchester City FC,Burnley FC,3,1,HOME_TEAM
+2023,2024-01-31,22,Liverpool FC,Chelsea FC,4,1,HOME_TEAM
+2023,2024-02-01,22,West Ham United FC,AFC Bournemouth,1,1,DRAW
+2023,2024-02-01,22,Wolverhampton Wanderers FC,Manchester United FC,3,4,AWAY_TEAM
+2023,2024-02-03,23,Everton FC,Tottenham Hotspur FC,2,2,DRAW
+2023,2024-02-03,23,Brighton & Hove Albion FC,Crystal Palace FC,4,1,HOME_TEAM
+2023,2024-02-03,23,Burnley FC,Fulham FC,2,2,DRAW
+2023,2024-02-03,23,Newcastle United FC,Luton Town FC,4,4,DRAW
+2023,2024-02-03,23,Sheffield United FC,Aston Villa FC,0,5,AWAY_TEAM
+2023,2024-02-04,23,AFC Bournemouth,Nottingham Forest FC,1,1,DRAW
+2023,2024-02-04,23,Chelsea FC,Wolverhampton Wanderers FC,2,4,AWAY_TEAM
+2023,2024-02-04,23,Manchester United FC,West Ham United FC,3,0,HOME_TEAM
+2023,2024-02-04,23,Arsenal FC,Liverpool FC,3,1,HOME_TEAM
+2023,2024-02-05,23,Brentford FC,Manchester City FC,1,3,AWAY_TEAM
+2023,2024-02-10,24,Manchester City FC,Everton FC,2,0,HOME_TEAM
+2023,2024-02-10,24,Fulham FC,AFC Bournemouth,3,1,HOME_TEAM
+2023,2024-02-10,24,Liverpool FC,Burnley FC,3,1,HOME_TEAM
+2023,2024-02-10,24,Luton Town FC,Sheffield United FC,1,3,AWAY_TEAM
+2023,2024-02-10,24,Tottenham Hotspur FC,Brighton & Hove Albion FC,2,1,HOME_TEAM
+2023,2024-02-10,24,Wolverhampton Wanderers FC,Brentford FC,0,2,AWAY_TEAM
+2023,2024-02-10,24,Nottingham Forest FC,Newcastle United FC,2,3,AWAY_TEAM
+2023,2024-02-11,24,West Ham United FC,Arsenal FC,0,6,AWAY_TEAM
+2023,2024-02-11,24,Aston Villa FC,Manchester United FC,1,2,AWAY_TEAM
+2023,2024-02-12,24,Crystal Palace FC,Chelsea FC,1,3,AWAY_TEAM
+2023,2024-02-17,25,Brentford FC,Liverpool FC,1,4,AWAY_TEAM
+2023,2024-02-17,25,Burnley FC,Arsenal FC,0,5,AWAY_TEAM
+2023,2024-02-17,25,Fulham FC,Aston Villa FC,1,2,AWAY_TEAM
+2023,2024-02-17,25,Newcastle United FC,AFC Bournemouth,2,2,DRAW
+2023,2024-02-17,25,Nottingham Forest FC,West Ham United FC,2,0,HOME_TEAM
+2023,2024-02-17,25,Tottenham Hotspur FC,Wolverhampton Wanderers FC,1,2,AWAY_TEAM
+2023,2024-02-17,25,Manchester City FC,Chelsea FC,1,1,DRAW
+2023,2024-02-18,25,Sheffield United FC,Brighton & Hove Albion FC,0,5,AWAY_TEAM
+2023,2024-02-18,25,Luton Town FC,Manchester United FC,1,2,AWAY_TEAM
+2023,2024-02-19,25,Everton FC,Crystal Palace FC,1,1,DRAW
+2023,2024-02-20,18,Manchester City FC,Brentford FC,1,0,HOME_TEAM
+2023,2024-02-21,26,Liverpool FC,Luton Town FC,4,1,HOME_TEAM
+2023,2024-02-24,26,Aston Villa FC,Nottingham Forest FC,4,2,HOME_TEAM
+2023,2024-02-24,26,Brighton & Hove Albion FC,Everton FC,1,1,DRAW
+2023,2024-02-24,26,Crystal Palace FC,Burnley FC,3,0,HOME_TEAM
+2023,2024-02-24,26,Manchester United FC,Fulham FC,1,2,AWAY_TEAM
+2023,2024-02-24,26,AFC Bournemouth,Manchester City FC,0,1,AWAY_TEAM
+2023,2024-02-24,26,Arsenal FC,Newcastle United FC,4,1,HOME_TEAM
+2023,2024-02-25,26,Wolverhampton Wanderers FC,Sheffield United FC,1,0,HOME_TEAM
+2023,2024-02-26,26,West Ham United FC,Brentford FC,4,2,HOME_TEAM
+2023,2024-03-02,27,Brentford FC,Chelsea FC,2,2,DRAW
+2023,2024-03-02,27,Everton FC,West Ham United FC,1,3,AWAY_TEAM
+2023,2024-03-02,27,Fulham FC,Brighton & Hove Albion FC,3,0,HOME_TEAM
+2023,2024-03-02,27,Newcastle United FC,Wolverhampton Wanderers FC,3,0,HOME_TEAM
+2023,2024-03-02,27,Nottingham Forest FC,Liverpool FC,0,1,AWAY_TEAM
+2023,2024-03-02,27,Tottenham Hotspur FC,Crystal Palace FC,3,1,HOME_TEAM
+2023,2024-03-02,27,Luton Town FC,Aston Villa FC,2,3,AWAY_TEAM
+2023,2024-03-03,27,Burnley FC,AFC Bournemouth,0,2,AWAY_TEAM
+2023,2024-03-03,27,Manchester City FC,Manchester United FC,3,1,HOME_TEAM
+2023,2024-03-04,27,Sheffield United FC,Arsenal FC,0,6,AWAY_TEAM
+2023,2024-03-09,28,Manchester United FC,Everton FC,2,0,HOME_TEAM
+2023,2024-03-09,28,AFC Bournemouth,Sheffield United FC,2,2,DRAW
+2023,2024-03-09,28,Crystal Palace FC,Luton Town FC,1,1,DRAW
+2023,2024-03-09,28,Wolverhampton Wanderers FC,Fulham FC,2,1,HOME_TEAM
+2023,2024-03-09,28,Arsenal FC,Brentford FC,2,1,HOME_TEAM
+2023,2024-03-10,28,Aston Villa FC,Tottenham Hotspur FC,0,4,AWAY_TEAM
+2023,2024-03-10,28,Brighton & Hove Albion FC,Nottingham Forest FC,1,0,HOME_TEAM
+2023,2024-03-10,28,West Ham United FC,Burnley FC,2,2,DRAW
+2023,2024-03-10,28,Liverpool FC,Manchester City FC,1,1,DRAW
+2023,2024-03-11,28,Chelsea FC,Newcastle United FC,3,2,HOME_TEAM
+2023,2024-03-13,17,AFC Bournemouth,Luton Town FC,4,3,HOME_TEAM
+2023,2024-03-16,29,Burnley FC,Brentford FC,2,1,HOME_TEAM
+2023,2024-03-16,29,Luton Town FC,Nottingham Forest FC,1,1,DRAW
+2023,2024-03-16,29,Fulham FC,Tottenham Hotspur FC,3,0,HOME_TEAM
+2023,2024-03-17,29,West Ham United FC,Aston Villa FC,1,1,DRAW
+2023,2024-03-30,30,Newcastle United FC,West Ham United FC,4,3,HOME_TEAM
+2023,2024-03-30,30,AFC Bournemouth,Everton FC,2,1,HOME_TEAM
+2023,2024-03-30,30,Chelsea FC,Burnley FC,2,2,DRAW
+2023,2024-03-30,30,Nottingham Forest FC,Crystal Palace FC,1,1,DRAW
+2023,2024-03-30,30,Sheffield United FC,Fulham FC,3,3,DRAW
+2023,2024-03-30,30,Tottenham Hotspur FC,Luton Town FC,2,1,HOME_TEAM
+2023,2024-03-30,30,Aston Villa FC,Wolverhampton Wanderers FC,2,0,HOME_TEAM
+2023,2024-03-30,30,Brentford FC,Manchester United FC,1,1,DRAW
+2023,2024-03-31,30,Liverpool FC,Brighton & Hove Albion FC,2,1,HOME_TEAM
+2023,2024-03-31,30,Manchester City FC,Arsenal FC,0,0,DRAW
+2023,2024-04-02,31,Nottingham Forest FC,Fulham FC,3,1,HOME_TEAM
+2023,2024-04-02,31,Newcastle United FC,Everton FC,1,1,DRAW
+2023,2024-04-02,31,AFC Bournemouth,Crystal Palace FC,1,0,HOME_TEAM
+2023,2024-04-02,31,Burnley FC,Wolverhampton Wanderers FC,1,1,DRAW
+2023,2024-04-02,31,West Ham United FC,Tottenham Hotspur FC,1,1,DRAW
+2023,2024-04-03,31,Arsenal FC,Luton Town FC,2,0,HOME_TEAM
+2023,2024-04-03,31,Brentford FC,Brighton & Hove Albion FC,0,0,DRAW
+2023,2024-04-03,31,Manchester City FC,Aston Villa FC,4,1,HOME_TEAM
+2023,2024-04-04,31,Liverpool FC,Sheffield United FC,3,1,HOME_TEAM
+2023,2024-04-04,31,Chelsea FC,Manchester United FC,4,3,HOME_TEAM
+2023,2024-04-06,32,Crystal Palace FC,Manchester City FC,2,4,AWAY_TEAM
+2023,2024-04-06,32,Aston Villa FC,Brentford FC,3,3,DRAW
+2023,2024-04-06,32,Everton FC,Burnley FC,1,0,HOME_TEAM
+2023,2024-04-06,32,Fulham FC,Newcastle United FC,0,1,AWAY_TEAM
+2023,2024-04-06,32,Luton Town FC,AFC Bournemouth,2,1,HOME_TEAM
+2023,2024-04-06,32,Wolverhampton Wanderers FC,West Ham United FC,1,2,AWAY_TEAM
+2023,2024-04-06,32,Brighton & Hove Albion FC,Arsenal FC,0,3,AWAY_TEAM
+2023,2024-04-07,32,Manchester United FC,Liverpool FC,2,2,DRAW
+2023,2024-04-07,32,Sheffield United FC,Chelsea FC,2,2,DRAW
+2023,2024-04-07,32,Tottenham Hotspur FC,Nottingham Forest FC,3,1,HOME_TEAM
+2023,2024-04-13,33,Newcastle United FC,Tottenham Hotspur FC,4,0,HOME_TEAM
+2023,2024-04-13,33,Brentford FC,Sheffield United FC,2,0,HOME_TEAM
+2023,2024-04-13,33,Burnley FC,Brighton & Hove Albion FC,1,1,DRAW
+2023,2024-04-13,33,Manchester City FC,Luton Town FC,5,1,HOME_TEAM
+2023,2024-04-13,33,Nottingham Forest FC,Wolverhampton Wanderers FC,2,2,DRAW
+2023,2024-04-13,33,AFC Bournemouth,Manchester United FC,2,2,DRAW
+2023,2024-04-14,33,Liverpool FC,Crystal Palace FC,0,1,AWAY_TEAM
+2023,2024-04-14,33,West Ham United FC,Fulham FC,0,2,AWAY_TEAM
+2023,2024-04-14,33,Arsenal FC,Aston Villa FC,0,2,AWAY_TEAM
+2023,2024-04-15,33,Chelsea FC,Everton FC,6,0,HOME_TEAM
+2023,2024-04-20,34,Luton Town FC,Brentford FC,1,5,AWAY_TEAM
+2023,2024-04-20,34,Sheffield United FC,Burnley FC,1,4,AWAY_TEAM
+2023,2024-04-20,34,Wolverhampton Wanderers FC,Arsenal FC,0,2,AWAY_TEAM
+2023,2024-04-21,34,Everton FC,Nottingham Forest FC,2,0,HOME_TEAM
+2023,2024-04-21,34,Aston Villa FC,AFC Bournemouth,3,1,HOME_TEAM
+2023,2024-04-21,34,Crystal Palace FC,West Ham United FC,5,2,HOME_TEAM
+2023,2024-04-21,34,Fulham FC,Liverpool FC,1,3,AWAY_TEAM
+2023,2024-04-23,29,Arsenal FC,Chelsea FC,5,0,HOME_TEAM
+2023,2024-04-24,29,Wolverhampton Wanderers FC,AFC Bournemouth,0,1,AWAY_TEAM
+2023,2024-04-24,29,Crystal Palace FC,Newcastle United FC,2,0,HOME_TEAM
+2023,2024-04-24,29,Everton FC,Liverpool FC,2,0,HOME_TEAM
+2023,2024-04-24,29,Manchester United FC,Sheffield United FC,4,2,HOME_TEAM
+2023,2024-04-25,29,Brighton & Hove Albion FC,Manchester City FC,0,4,AWAY_TEAM
+2023,2024-04-27,35,West Ham United FC,Liverpool FC,2,2,DRAW
+2023,2024-04-27,35,Fulham FC,Crystal Palace FC,1,1,DRAW
+2023,2024-04-27,35,Manchester United FC,Burnley FC,1,1,DRAW
+2023,2024-04-27,35,Newcastle United FC,Sheffield United FC,5,1,HOME_TEAM
+2023,2024-04-27,35,Wolverhampton Wanderers FC,Luton Town FC,2,1,HOME_TEAM
+2023,2024-04-27,35,Everton FC,Brentford FC,1,0,HOME_TEAM
+2023,2024-04-27,35,Aston Villa FC,Chelsea FC,2,2,DRAW
+2023,2024-04-28,35,AFC Bournemouth,Brighton & Hove Albion FC,3,0,HOME_TEAM
+2023,2024-04-28,35,Tottenham Hotspur FC,Arsenal FC,2,3,AWAY_TEAM
+2023,2024-04-28,35,Nottingham Forest FC,Manchester City FC,0,2,AWAY_TEAM
+2023,2024-05-02,26,Chelsea FC,Tottenham Hotspur FC,2,0,HOME_TEAM
+2023,2024-05-03,36,Luton Town FC,Everton FC,1,1,DRAW
+2023,2024-05-04,36,Arsenal FC,AFC Bournemouth,3,0,HOME_TEAM
+2023,2024-05-04,36,Brentford FC,Fulham FC,0,0,DRAW
+2023,2024-05-04,36,Burnley FC,Newcastle United FC,1,4,AWAY_TEAM
+2023,2024-05-04,36,Sheffield United FC,Nottingham Forest FC,1,3,AWAY_TEAM
+2023,2024-05-04,36,Manchester City FC,Wolverhampton Wanderers FC,5,1,HOME_TEAM
+2023,2024-05-05,36,Brighton & Hove Albion FC,Aston Villa FC,1,0,HOME_TEAM
+2023,2024-05-05,36,Chelsea FC,West Ham United FC,5,0,HOME_TEAM
+2023,2024-05-05,36,Liverpool FC,Tottenham Hotspur FC,4,2,HOME_TEAM
+2023,2024-05-06,36,Crystal Palace FC,Manchester United FC,4,0,HOME_TEAM
+2023,2024-05-11,37,Fulham FC,Manchester City FC,0,4,AWAY_TEAM
+2023,2024-05-11,37,AFC Bournemouth,Brentford FC,1,2,AWAY_TEAM
+2023,2024-05-11,37,Everton FC,Sheffield United FC,1,0,HOME_TEAM
+2023,2024-05-11,37,Newcastle United FC,Brighton & Hove Albion FC,1,1,DRAW
+2023,2024-05-11,37,Tottenham Hotspur FC,Burnley FC,2,1,HOME_TEAM
+2023,2024-05-11,37,West Ham United FC,Luton Town FC,3,1,HOME_TEAM
+2023,2024-05-11,37,Wolverhampton Wanderers FC,Crystal Palace FC,1,3,AWAY_TEAM
+2023,2024-05-11,37,Nottingham Forest FC,Chelsea FC,2,3,AWAY_TEAM
+2023,2024-05-12,37,Manchester United FC,Arsenal FC,0,1,AWAY_TEAM
+2023,2024-05-13,37,Aston Villa FC,Liverpool FC,3,3,DRAW
+2023,2024-05-14,34,Tottenham Hotspur FC,Manchester City FC,0,2,AWAY_TEAM
+2023,2024-05-15,34,Brighton & Hove Albion FC,Chelsea FC,1,2,AWAY_TEAM
+2023,2024-05-15,34,Manchester United FC,Newcastle United FC,3,2,HOME_TEAM
+2023,2024-05-19,38,Arsenal FC,Everton FC,2,1,HOME_TEAM
+2023,2024-05-19,38,Brentford FC,Newcastle United FC,2,4,AWAY_TEAM
+2023,2024-05-19,38,Brighton & Hove Albion FC,Manchester United FC,0,2,AWAY_TEAM
+2023,2024-05-19,38,Burnley FC,Nottingham Forest FC,1,2,AWAY_TEAM
+2023,2024-05-19,38,Chelsea FC,AFC Bournemouth,2,1,HOME_TEAM
+2023,2024-05-19,38,Crystal Palace FC,Aston Villa FC,5,0,HOME_TEAM
+2023,2024-05-19,38,Liverpool FC,Wolverhampton Wanderers FC,2,0,HOME_TEAM
+2023,2024-05-19,38,Luton Town FC,Fulham FC,2,4,AWAY_TEAM
+2023,2024-05-19,38,Manchester City FC,West Ham United FC,3,1,HOME_TEAM
+2023,2024-05-19,38,Sheffield United FC,Tottenham Hotspur FC,0,3,AWAY_TEAM
+2024,2024-08-16,1,Manchester United FC,Fulham FC,1,0,HOME_TEAM
+2024,2024-08-17,1,Ipswich Town FC,Liverpool FC,0,2,AWAY_TEAM
+2024,2024-08-17,1,Arsenal FC,Wolverhampton Wanderers FC,2,0,HOME_TEAM
+2024,2024-08-17,1,Everton FC,Brighton & Hove Albion FC,0,3,AWAY_TEAM
+2024,2024-08-17,1,Newcastle United FC,Southampton FC,1,0,HOME_TEAM
+2024,2024-08-17,1,Nottingham Forest FC,AFC Bournemouth,1,1,DRAW
+2024,2024-08-17,1,West Ham United FC,Aston Villa FC,1,2,AWAY_TEAM
+2024,2024-08-18,1,Brentford FC,Crystal Palace FC,2,1,HOME_TEAM
+2024,2024-08-18,1,Chelsea FC,Manchester City FC,0,2,AWAY_TEAM
+2024,2024-08-19,1,Leicester City FC,Tottenham Hotspur FC,1,1,DRAW
+2024,2024-08-24,2,Brighton & Hove Albion FC,Manchester United FC,2,1,HOME_TEAM
+2024,2024-08-24,2,Crystal Palace FC,West Ham United FC,0,2,AWAY_TEAM
+2024,2024-08-24,2,Fulham FC,Leicester City FC,2,1,HOME_TEAM
+2024,2024-08-24,2,Manchester City FC,Ipswich Town FC,4,1,HOME_TEAM
+2024,2024-08-24,2,Southampton FC,Nottingham Forest FC,0,1,AWAY_TEAM
+2024,2024-08-24,2,Tottenham Hotspur FC,Everton FC,4,0,HOME_TEAM
+2024,2024-08-24,2,Aston Villa FC,Arsenal FC,0,2,AWAY_TEAM
+2024,2024-08-25,2,AFC Bournemouth,Newcastle United FC,1,1,DRAW
+2024,2024-08-25,2,Wolverhampton Wanderers FC,Chelsea FC,2,6,AWAY_TEAM
+2024,2024-08-25,2,Liverpool FC,Brentford FC,2,0,HOME_TEAM
+2024,2024-08-31,3,Arsenal FC,Brighton & Hove Albion FC,1,1,DRAW
+2024,2024-08-31,3,Brentford FC,Southampton FC,3,1,HOME_TEAM
+2024,2024-08-31,3,Everton FC,AFC Bournemouth,2,3,AWAY_TEAM
+2024,2024-08-31,3,Ipswich Town FC,Fulham FC,1,1,DRAW
+2024,2024-08-31,3,Leicester City FC,Aston Villa FC,1,2,AWAY_TEAM
+2024,2024-08-31,3,Nottingham Forest FC,Wolverhampton Wanderers FC,1,1,DRAW
+2024,2024-08-31,3,West Ham United FC,Manchester City FC,1,3,AWAY_TEAM
+2024,2024-09-01,3,Chelsea FC,Crystal Palace FC,1,1,DRAW
+2024,2024-09-01,3,Newcastle United FC,Tottenham Hotspur FC,2,1,HOME_TEAM
+2024,2024-09-01,3,Manchester United FC,Liverpool FC,0,3,AWAY_TEAM
+2024,2024-09-14,4,Southampton FC,Manchester United FC,0,3,AWAY_TEAM
+2024,2024-09-14,4,Brighton & Hove Albion FC,Ipswich Town FC,0,0,DRAW
+2024,2024-09-14,4,Crystal Palace FC,Leicester City FC,2,2,DRAW
+2024,2024-09-14,4,Fulham FC,West Ham United FC,1,1,DRAW
+2024,2024-09-14,4,Liverpool FC,Nottingham Forest FC,0,1,AWAY_TEAM
+2024,2024-09-14,4,Manchester City FC,Brentford FC,2,1,HOME_TEAM
+2024,2024-09-14,4,Aston Villa FC,Everton FC,3,2,HOME_TEAM
+2024,2024-09-14,4,AFC Bournemouth,Chelsea FC,0,1,AWAY_TEAM
+2024,2024-09-15,4,Tottenham Hotspur FC,Arsenal FC,0,1,AWAY_TEAM
+2024,2024-09-15,4,Wolverhampton Wanderers FC,Newcastle United FC,1,2,AWAY_TEAM
+2024,2024-09-21,5,West Ham United FC,Chelsea FC,0,3,AWAY_TEAM
+2024,2024-09-21,5,Aston Villa FC,Wolverhampton Wanderers FC,3,1,HOME_TEAM
+2024,2024-09-21,5,Fulham FC,Newcastle United FC,3,1,HOME_TEAM
+2024,2024-09-21,5,Leicester City FC,Everton FC,1,1,DRAW
+2024,2024-09-21,5,Liverpool FC,AFC Bournemouth,3,0,HOME_TEAM
+2024,2024-09-21,5,Southampton FC,Ipswich Town FC,1,1,DRAW
+2024,2024-09-21,5,Tottenham Hotspur FC,Brentford FC,3,1,HOME_TEAM
+2024,2024-09-21,5,Crystal Palace FC,Manchester United FC,0,0,DRAW
+2024,2024-09-22,5,Brighton & Hove Albion FC,Nottingham Forest FC,2,2,DRAW
+2024,2024-09-22,5,Manchester City FC,Arsenal FC,2,2,DRAW
+2024,2024-09-28,6,Newcastle United FC,Manchester City FC,1,1,DRAW
+2024,2024-09-28,6,Arsenal FC,Leicester City FC,4,2,HOME_TEAM
+2024,2024-09-28,6,Brentford FC,West Ham United FC,1,1,DRAW
+2024,2024-09-28,6,Chelsea FC,Brighton & Hove Albion FC,4,2,HOME_TEAM
+2024,2024-09-28,6,Everton FC,Crystal Palace FC,2,1,HOME_TEAM
+2024,2024-09-28,6,Nottingham Forest FC,Fulham FC,0,1,AWAY_TEAM
+2024,2024-09-28,6,Wolverhampton Wanderers FC,Liverpool FC,1,2,AWAY_TEAM
+2024,2024-09-29,6,Ipswich Town FC,Aston Villa FC,2,2,DRAW
+2024,2024-09-29,6,Manchester United FC,Tottenham Hotspur FC,0,3,AWAY_TEAM
+2024,2024-09-30,6,AFC Bournemouth,Southampton FC,3,1,HOME_TEAM
+2024,2024-10-05,7,Crystal Palace FC,Liverpool FC,0,1,AWAY_TEAM
+2024,2024-10-05,7,Arsenal FC,Southampton FC,3,1,HOME_TEAM
+2024,2024-10-05,7,Brentford FC,Wolverhampton Wanderers FC,5,3,HOME_TEAM
+2024,2024-10-05,7,Leicester City FC,AFC Bournemouth,1,0,HOME_TEAM
+2024,2024-10-05,7,Manchester City FC,Fulham FC,3,2,HOME_TEAM
+2024,2024-10-05,7,West Ham United FC,Ipswich Town FC,4,1,HOME_TEAM
+2024,2024-10-05,7,Everton FC,Newcastle United FC,0,0,DRAW
+2024,2024-10-06,7,Aston Villa FC,Manchester United FC,0,0,DRAW
+2024,2024-10-06,7,Chelsea FC,Nottingham Forest FC,1,1,DRAW
+2024,2024-10-06,7,Brighton & Hove Albion FC,Tottenham Hotspur FC,3,2,HOME_TEAM
+2024,2024-10-19,8,Tottenham Hotspur FC,West Ham United FC,4,1,HOME_TEAM
+2024,2024-10-19,8,Fulham FC,Aston Villa FC,1,3,AWAY_TEAM
+2024,2024-10-19,8,Ipswich Town FC,Everton FC,0,2,AWAY_TEAM
+2024,2024-10-19,8,Manchester United FC,Brentford FC,2,1,HOME_TEAM
+2024,2024-10-19,8,Newcastle United FC,Brighton & Hove Albion FC,0,1,AWAY_TEAM
+2024,2024-10-19,8,Southampton FC,Leicester City FC,2,3,AWAY_TEAM
+2024,2024-10-19,8,AFC Bournemouth,Arsenal FC,2,0,HOME_TEAM
+2024,2024-10-20,8,Wolverhampton Wanderers FC,Manchester City FC,1,2,AWAY_TEAM
+2024,2024-10-20,8,Liverpool FC,Chelsea FC,2,1,HOME_TEAM
+2024,2024-10-21,8,Nottingham Forest FC,Crystal Palace FC,1,0,HOME_TEAM
+2024,2024-10-25,9,Leicester City FC,Nottingham Forest FC,1,3,AWAY_TEAM
+2024,2024-10-26,9,Aston Villa FC,AFC Bournemouth,1,1,DRAW
+2024,2024-10-26,9,Brentford FC,Ipswich Town FC,4,3,HOME_TEAM
+2024,2024-10-26,9,Brighton & Hove Albion FC,Wolverhampton Wanderers FC,2,2,DRAW
+2024,2024-10-26,9,Manchester City FC,Southampton FC,1,0,HOME_TEAM
+2024,2024-10-26,9,Everton FC,Fulham FC,1,1,DRAW
+2024,2024-10-27,9,Chelsea FC,Newcastle United FC,2,1,HOME_TEAM
+2024,2024-10-27,9,Crystal Palace FC,Tottenham Hotspur FC,1,0,HOME_TEAM
+2024,2024-10-27,9,West Ham United FC,Manchester United FC,2,1,HOME_TEAM
+2024,2024-10-27,9,Arsenal FC,Liverpool FC,2,2,DRAW
+2024,2024-11-02,10,Newcastle United FC,Arsenal FC,1,0,HOME_TEAM
+2024,2024-11-02,10,AFC Bournemouth,Manchester City FC,2,1,HOME_TEAM
+2024,2024-11-02,10,Ipswich Town FC,Leicester City FC,1,1,DRAW
+2024,2024-11-02,10,Liverpool FC,Brighton & Hove Albion FC,2,1,HOME_TEAM
+2024,2024-11-02,10,Nottingham Forest FC,West Ham United FC,3,0,HOME_TEAM
+2024,2024-11-02,10,Southampton FC,Everton FC,1,0,HOME_TEAM
+2024,2024-11-02,10,Wolverhampton Wanderers FC,Crystal Palace FC,2,2,DRAW
+2024,2024-11-03,10,Tottenham Hotspur FC,Aston Villa FC,4,1,HOME_TEAM
+2024,2024-11-03,10,Manchester United FC,Chelsea FC,1,1,DRAW
+2024,2024-11-04,10,Fulham FC,Brentford FC,2,1,HOME_TEAM
+2024,2024-11-09,11,Brentford FC,AFC Bournemouth,3,2,HOME_TEAM
+2024,2024-11-09,11,Crystal Palace FC,Fulham FC,0,2,AWAY_TEAM
+2024,2024-11-09,11,West Ham United FC,Everton FC,0,0,DRAW
+2024,2024-11-09,11,Wolverhampton Wanderers FC,Southampton FC,2,0,HOME_TEAM
+2024,2024-11-09,11,Brighton & Hove Albion FC,Manchester City FC,2,1,HOME_TEAM
+2024,2024-11-09,11,Liverpool FC,Aston Villa FC,2,0,HOME_TEAM
+2024,2024-11-10,11,Manchester United FC,Leicester City FC,3,0,HOME_TEAM
+2024,2024-11-10,11,Nottingham Forest FC,Newcastle United FC,1,3,AWAY_TEAM
+2024,2024-11-10,11,Tottenham Hotspur FC,Ipswich Town FC,1,2,AWAY_TEAM
+2024,2024-11-10,11,Chelsea FC,Arsenal FC,1,1,DRAW
+2024,2024-11-23,12,Leicester City FC,Chelsea FC,1,2,AWAY_TEAM
+2024,2024-11-23,12,AFC Bournemouth,Brighton & Hove Albion FC,1,2,AWAY_TEAM
+2024,2024-11-23,12,Arsenal FC,Nottingham Forest FC,3,0,HOME_TEAM
+2024,2024-11-23,12,Aston Villa FC,Crystal Palace FC,2,2,DRAW
+2024,2024-11-23,12,Everton FC,Brentford FC,0,0,DRAW
+2024,2024-11-23,12,Fulham FC,Wolverhampton Wanderers FC,1,4,AWAY_TEAM
+2024,2024-11-23,12,Manchester City FC,Tottenham Hotspur FC,0,4,AWAY_TEAM
+2024,2024-11-24,12,Southampton FC,Liverpool FC,2,3,AWAY_TEAM
+2024,2024-11-24,12,Ipswich Town FC,Manchester United FC,1,1,DRAW
+2024,2024-11-25,12,Newcastle United FC,West Ham United FC,0,2,AWAY_TEAM
+2024,2024-11-29,13,Brighton & Hove Albion FC,Southampton FC,1,1,DRAW
+2024,2024-11-30,13,Brentford FC,Leicester City FC,4,1,HOME_TEAM
+2024,2024-11-30,13,Crystal Palace FC,Newcastle United FC,1,1,DRAW
+2024,2024-11-30,13,Nottingham Forest FC,Ipswich Town FC,1,0,HOME_TEAM
+2024,2024-11-30,13,Wolverhampton Wanderers FC,AFC Bournemouth,2,4,AWAY_TEAM
+2024,2024-11-30,13,West Ham United FC,Arsenal FC,2,5,AWAY_TEAM
+2024,2024-12-01,13,Chelsea FC,Aston Villa FC,3,0,HOME_TEAM
+2024,2024-12-01,13,Manchester United FC,Everton FC,4,0,HOME_TEAM
+2024,2024-12-01,13,Tottenham Hotspur FC,Fulham FC,1,1,DRAW
+2024,2024-12-01,13,Liverpool FC,Manchester City FC,2,0,HOME_TEAM
+2024,2024-12-03,14,Ipswich Town FC,Crystal Palace FC,0,1,AWAY_TEAM
+2024,2024-12-03,14,Leicester City FC,West Ham United FC,3,1,HOME_TEAM
+2024,2024-12-04,14,Everton FC,Wolverhampton Wanderers FC,4,0,HOME_TEAM
+2024,2024-12-04,14,Manchester City FC,Nottingham Forest FC,3,0,HOME_TEAM
+2024,2024-12-04,14,Newcastle United FC,Liverpool FC,3,3,DRAW
+2024,2024-12-04,14,Southampton FC,Chelsea FC,1,5,AWAY_TEAM
+2024,2024-12-04,14,Arsenal FC,Manchester United FC,2,0,HOME_TEAM
+2024,2024-12-04,14,Aston Villa FC,Brentford FC,3,1,HOME_TEAM
+2024,2024-12-05,14,Fulham FC,Brighton & Hove Albion FC,3,1,HOME_TEAM
+2024,2024-12-05,14,AFC Bournemouth,Tottenham Hotspur FC,1,0,HOME_TEAM
+2024,2024-12-07,15,Aston Villa FC,Southampton FC,1,0,HOME_TEAM
+2024,2024-12-07,15,Brentford FC,Newcastle United FC,4,2,HOME_TEAM
+2024,2024-12-07,15,Crystal Palace FC,Manchester City FC,2,2,DRAW
+2024,2024-12-07,15,Manchester United FC,Nottingham Forest FC,2,3,AWAY_TEAM
+2024,2024-12-08,15,Fulham FC,Arsenal FC,1,1,DRAW
+2024,2024-12-08,15,Ipswich Town FC,AFC Bournemouth,1,2,AWAY_TEAM
+2024,2024-12-08,15,Leicester City FC,Brighton & Hove Albion FC,2,2,DRAW
+2024,2024-12-08,15,Tottenham Hotspur FC,Chelsea FC,3,4,AWAY_TEAM
+2024,2024-12-09,15,West Ham United FC,Wolverhampton Wanderers FC,2,1,HOME_TEAM
+2024,2024-12-14,16,Arsenal FC,Everton FC,0,0,DRAW
+2024,2024-12-14,16,Liverpool FC,Fulham FC,2,2,DRAW
+2024,2024-12-14,16,Newcastle United FC,Leicester City FC,4,0,HOME_TEAM
+2024,2024-12-14,16,Wolverhampton Wanderers FC,Ipswich Town FC,1,2,AWAY_TEAM
+2024,2024-12-14,16,Nottingham Forest FC,Aston Villa FC,2,1,HOME_TEAM
+2024,2024-12-15,16,Brighton & Hove Albion FC,Crystal Palace FC,1,3,AWAY_TEAM
+2024,2024-12-15,16,Manchester City FC,Manchester United FC,1,2,AWAY_TEAM
+2024,2024-12-15,16,Chelsea FC,Brentford FC,2,1,HOME_TEAM
+2024,2024-12-15,16,Southampton FC,Tottenham Hotspur FC,0,5,AWAY_TEAM
+2024,2024-12-16,16,AFC Bournemouth,West Ham United FC,1,1,DRAW
+2024,2024-12-21,17,Aston Villa FC,Manchester City FC,2,1,HOME_TEAM
+2024,2024-12-21,17,Brentford FC,Nottingham Forest FC,0,2,AWAY_TEAM
+2024,2024-12-21,17,Ipswich Town FC,Newcastle United FC,0,4,AWAY_TEAM
+2024,2024-12-21,17,West Ham United FC,Brighton & Hove Albion FC,1,1,DRAW
+2024,2024-12-21,17,Crystal Palace FC,Arsenal FC,1,5,AWAY_TEAM
+2024,2024-12-22,17,Everton FC,Chelsea FC,0,0,DRAW
+2024,2024-12-22,17,Fulham FC,Southampton FC,0,0,DRAW
+2024,2024-12-22,17,Leicester City FC,Wolverhampton Wanderers FC,0,3,AWAY_TEAM
+2024,2024-12-22,17,Manchester United FC,AFC Bournemouth,0,3,AWAY_TEAM
+2024,2024-12-22,17,Tottenham Hotspur FC,Liverpool FC,3,6,AWAY_TEAM
+2024,2024-12-26,18,Manchester City FC,Everton FC,1,1,DRAW
+2024,2024-12-26,18,AFC Bournemouth,Crystal Palace FC,0,0,DRAW
+2024,2024-12-26,18,Chelsea FC,Fulham FC,1,2,AWAY_TEAM
+2024,2024-12-26,18,Newcastle United FC,Aston Villa FC,3,0,HOME_TEAM
+2024,2024-12-26,18,Nottingham Forest FC,Tottenham Hotspur FC,1,0,HOME_TEAM
+2024,2024-12-26,18,Southampton FC,West Ham United FC,0,1,AWAY_TEAM
+2024,2024-12-26,18,Wolverhampton Wanderers FC,Manchester United FC,2,0,HOME_TEAM
+2024,2024-12-26,18,Liverpool FC,Leicester City FC,3,1,HOME_TEAM
+2024,2024-12-27,18,Brighton & Hove Albion FC,Brentford FC,0,0,DRAW
+2024,2024-12-27,18,Arsenal FC,Ipswich Town FC,1,0,HOME_TEAM
+2024,2024-12-29,19,Leicester City FC,Manchester City FC,0,2,AWAY_TEAM
+2024,2024-12-29,19,Crystal Palace FC,Southampton FC,2,1,HOME_TEAM
+2024,2024-12-29,19,Everton FC,Nottingham Forest FC,0,2,AWAY_TEAM
+2024,2024-12-29,19,Fulham FC,AFC Bournemouth,2,2,DRAW
+2024,2024-12-29,19,Tottenham Hotspur FC,Wolverhampton Wanderers FC,2,2,DRAW
+2024,2024-12-29,19,West Ham United FC,Liverpool FC,0,5,AWAY_TEAM
+2024,2024-12-30,19,Aston Villa FC,Brighton & Hove Albion FC,2,2,DRAW
+2024,2024-12-30,19,Ipswich Town FC,Chelsea FC,2,0,HOME_TEAM
+2024,2024-12-30,19,Manchester United FC,Newcastle United FC,0,2,AWAY_TEAM
+2024,2025-01-01,19,Brentford FC,Arsenal FC,1,3,AWAY_TEAM
+2024,2025-01-04,20,Tottenham Hotspur FC,Newcastle United FC,1,2,AWAY_TEAM
+2024,2025-01-04,20,Southampton FC,Brentford FC,0,5,AWAY_TEAM
+2024,2025-01-04,20,Crystal Palace FC,Chelsea FC,1,1,DRAW
+2024,2025-01-04,20,AFC Bournemouth,Everton FC,1,0,HOME_TEAM
+2024,2025-01-04,20,Aston Villa FC,Leicester City FC,2,1,HOME_TEAM
+2024,2025-01-04,20,Manchester City FC,West Ham United FC,4,1,HOME_TEAM
+2024,2025-01-04,20,Brighton & Hove Albion FC,Arsenal FC,1,1,DRAW
+2024,2025-01-05,20,Fulham FC,Ipswich Town FC,2,2,DRAW
+2024,2025-01-05,20,Liverpool FC,Manchester United FC,2,2,DRAW
+2024,2025-01-06,20,Wolverhampton Wanderers FC,Nottingham Forest FC,0,3,AWAY_TEAM
+2024,2025-01-14,21,West Ham United FC,Fulham FC,3,2,HOME_TEAM
+2024,2025-01-14,21,Brentford FC,Manchester City FC,2,2,DRAW
+2024,2025-01-14,21,Chelsea FC,AFC Bournemouth,2,2,DRAW
+2024,2025-01-14,21,Nottingham Forest FC,Liverpool FC,1,1,DRAW
+2024,2025-01-15,21,Everton FC,Aston Villa FC,0,1,AWAY_TEAM
+2024,2025-01-15,21,Leicester City FC,Crystal Palace FC,0,2,AWAY_TEAM
+2024,2025-01-15,21,Newcastle United FC,Wolverhampton Wanderers FC,3,0,HOME_TEAM
+2024,2025-01-15,21,Arsenal FC,Tottenham Hotspur FC,2,1,HOME_TEAM
+2024,2025-01-16,21,Ipswich Town FC,Brighton & Hove Albion FC,0,2,AWAY_TEAM
+2024,2025-01-16,21,Manchester United FC,Southampton FC,3,1,HOME_TEAM
+2024,2025-01-18,22,Newcastle United FC,AFC Bournemouth,1,4,AWAY_TEAM
+2024,2025-01-18,22,West Ham United FC,Crystal Palace FC,0,2,AWAY_TEAM
+2024,2025-01-18,22,Leicester City FC,Fulham FC,0,2,AWAY_TEAM
+2024,2025-01-18,22,Brentford FC,Liverpool FC,0,2,AWAY_TEAM
+2024,2025-01-18,22,Arsenal FC,Aston Villa FC,2,2,DRAW
+2024,2025-01-19,22,Manchester United FC,Brighton & Hove Albion FC,1,3,AWAY_TEAM
+2024,2025-01-19,22,Nottingham Forest FC,Southampton FC,3,2,HOME_TEAM
+2024,2025-01-19,22,Everton FC,Tottenham Hotspur FC,3,2,HOME_TEAM
+2024,2025-01-19,22,Ipswich Town FC,Manchester City FC,0,6,AWAY_TEAM
+2024,2025-01-20,22,Chelsea FC,Wolverhampton Wanderers FC,3,1,HOME_TEAM
+2024,2025-01-25,23,Liverpool FC,Ipswich Town FC,4,1,HOME_TEAM
+2024,2025-01-25,23,Wolverhampton Wanderers FC,Arsenal FC,0,1,AWAY_TEAM
+2024,2025-01-25,23,Brighton & Hove Albion FC,Everton FC,0,1,AWAY_TEAM
+2024,2025-01-25,23,Southampton FC,Newcastle United FC,1,3,AWAY_TEAM
+2024,2025-01-25,23,AFC Bournemouth,Nottingham Forest FC,5,0,HOME_TEAM
+2024,2025-01-25,23,Manchester City FC,Chelsea FC,3,1,HOME_TEAM
+2024,2025-01-26,23,Crystal Palace FC,Brentford FC,1,2,AWAY_TEAM
+2024,2025-01-26,23,Tottenham Hotspur FC,Leicester City FC,1,2,AWAY_TEAM
+2024,2025-01-26,23,Aston Villa FC,West Ham United FC,1,1,DRAW
+2024,2025-01-26,23,Fulham FC,Manchester United FC,0,1,AWAY_TEAM
+2024,2025-02-01,24,Nottingham Forest FC,Brighton & Hove Albion FC,7,0,HOME_TEAM
+2024,2025-02-01,24,Newcastle United FC,Fulham FC,1,2,AWAY_TEAM
+2024,2025-02-01,24,Everton FC,Leicester City FC,4,0,HOME_TEAM
+2024,2025-02-01,24,AFC Bournemouth,Liverpool FC,0,2,AWAY_TEAM
+2024,2025-02-01,24,Ipswich Town FC,Southampton FC,1,2,AWAY_TEAM
+2024,2025-02-01,24,Wolverhampton Wanderers FC,Aston Villa FC,2,0,HOME_TEAM
+2024,2025-02-02,24,Manchester United FC,Crystal Palace FC,0,2,AWAY_TEAM
+2024,2025-02-02,24,Brentford FC,Tottenham Hotspur FC,0,2,AWAY_TEAM
+2024,2025-02-02,24,Arsenal FC,Manchester City FC,5,1,HOME_TEAM
+2024,2025-02-03,24,Chelsea FC,West Ham United FC,2,1,HOME_TEAM
+2024,2025-02-12,15,Everton FC,Liverpool FC,2,2,DRAW
+2024,2025-02-14,25,Brighton & Hove Albion FC,Chelsea FC,3,0,HOME_TEAM
+2024,2025-02-15,25,Leicester City FC,Arsenal FC,0,2,AWAY_TEAM
+2024,2025-02-15,25,Southampton FC,AFC Bournemouth,1,3,AWAY_TEAM
+2024,2025-02-15,25,West Ham United FC,Brentford FC,0,1,AWAY_TEAM
+2024,2025-02-15,25,Aston Villa FC,Ipswich Town FC,1,1,DRAW
+2024,2025-02-15,25,Manchester City FC,Newcastle United FC,4,0,HOME_TEAM
+2024,2025-02-15,25,Fulham FC,Nottingham Forest FC,2,1,HOME_TEAM
+2024,2025-02-15,25,Crystal Palace FC,Everton FC,1,2,AWAY_TEAM
+2024,2025-02-16,25,Liverpool FC,Wolverhampton Wanderers FC,2,1,HOME_TEAM
+2024,2025-02-16,25,Tottenham Hotspur FC,Manchester United FC,1,0,HOME_TEAM
+2024,2025-02-19,29,Aston Villa FC,Liverpool FC,2,2,DRAW
+2024,2025-02-21,26,Leicester City FC,Brentford FC,0,4,AWAY_TEAM
+2024,2025-02-22,26,Everton FC,Manchester United FC,2,2,DRAW
+2024,2025-02-22,26,Ipswich Town FC,Tottenham Hotspur FC,1,4,AWAY_TEAM
+2024,2025-02-22,26,Fulham FC,Crystal Palace FC,0,2,AWAY_TEAM
+2024,2025-02-22,26,Arsenal FC,West Ham United FC,0,1,AWAY_TEAM
+2024,2025-02-22,26,AFC Bournemouth,Wolverhampton Wanderers FC,0,1,AWAY_TEAM
+2024,2025-02-22,26,Southampton FC,Brighton & Hove Albion FC,0,4,AWAY_TEAM
+2024,2025-02-22,26,Aston Villa FC,Chelsea FC,2,1,HOME_TEAM
+2024,2025-02-23,26,Newcastle United FC,Nottingham Forest FC,4,3,HOME_TEAM
+2024,2025-02-23,26,Manchester City FC,Liverpool FC,0,2,AWAY_TEAM
+2024,2025-02-25,27,Brighton & Hove Albion FC,AFC Bournemouth,2,1,HOME_TEAM
+2024,2025-02-25,27,Crystal Palace FC,Aston Villa FC,4,1,HOME_TEAM
+2024,2025-02-25,27,Wolverhampton Wanderers FC,Fulham FC,1,2,AWAY_TEAM
+2024,2025-02-25,27,Chelsea FC,Southampton FC,4,0,HOME_TEAM
+2024,2025-02-26,27,Nottingham Forest FC,Arsenal FC,0,0,DRAW
+2024,2025-02-26,27,Brentford FC,Everton FC,1,1,DRAW
+2024,2025-02-26,27,Tottenham Hotspur FC,Manchester City FC,0,1,AWAY_TEAM
+2024,2025-02-26,27,Manchester United FC,Ipswich Town FC,3,2,HOME_TEAM
+2024,2025-02-26,27,Liverpool FC,Newcastle United FC,2,0,HOME_TEAM
+2024,2025-02-27,27,West Ham United FC,Leicester City FC,2,0,HOME_TEAM
+2024,2025-03-08,28,Nottingham Forest FC,Manchester City FC,1,0,HOME_TEAM
+2024,2025-03-08,28,Brighton & Hove Albion FC,Fulham FC,2,1,HOME_TEAM
+2024,2025-03-08,28,Crystal Palace FC,Ipswich Town FC,1,0,HOME_TEAM
+2024,2025-03-08,28,Liverpool FC,Southampton FC,3,1,HOME_TEAM
+2024,2025-03-08,28,Brentford FC,Aston Villa FC,0,1,AWAY_TEAM
+2024,2025-03-08,28,Wolverhampton Wanderers FC,Everton FC,1,1,DRAW
+2024,2025-03-09,28,Tottenham Hotspur FC,AFC Bournemouth,2,2,DRAW
+2024,2025-03-09,28,Chelsea FC,Leicester City FC,1,0,HOME_TEAM
+2024,2025-03-09,28,Manchester United FC,Arsenal FC,1,1,DRAW
+2024,2025-03-10,28,West Ham United FC,Newcastle United FC,0,1,AWAY_TEAM
+2024,2025-03-15,29,Everton FC,West Ham United FC,1,1,DRAW
+2024,2025-03-15,29,Ipswich Town FC,Nottingham Forest FC,2,4,AWAY_TEAM
+2024,2025-03-15,29,Manchester City FC,Brighton & Hove Albion FC,2,2,DRAW
+2024,2025-03-15,29,Southampton FC,Wolverhampton Wanderers FC,1,2,AWAY_TEAM
+2024,2025-03-15,29,AFC Bournemouth,Brentford FC,1,2,AWAY_TEAM
+2024,2025-03-16,29,Arsenal FC,Chelsea FC,1,0,HOME_TEAM
+2024,2025-03-16,29,Fulham FC,Tottenham Hotspur FC,2,0,HOME_TEAM
+2024,2025-03-16,29,Leicester City FC,Manchester United FC,0,3,AWAY_TEAM
+2024,2025-04-01,30,Arsenal FC,Fulham FC,2,1,HOME_TEAM
+2024,2025-04-01,30,Wolverhampton Wanderers FC,West Ham United FC,1,0,HOME_TEAM
+2024,2025-04-01,30,Nottingham Forest FC,Manchester United FC,1,0,HOME_TEAM
+2024,2025-04-02,30,AFC Bournemouth,Ipswich Town FC,1,2,AWAY_TEAM
+2024,2025-04-02,30,Brighton & Hove Albion FC,Aston Villa FC,0,3,AWAY_TEAM
+2024,2025-04-02,30,Manchester City FC,Leicester City FC,2,0,HOME_TEAM
+2024,2025-04-02,30,Newcastle United FC,Brentford FC,2,1,HOME_TEAM
+2024,2025-04-02,30,Southampton FC,Crystal Palace FC,1,1,DRAW
+2024,2025-04-02,30,Liverpool FC,Everton FC,1,0,HOME_TEAM
+2024,2025-04-03,30,Chelsea FC,Tottenham Hotspur FC,1,0,HOME_TEAM
+2024,2025-04-05,31,Everton FC,Arsenal FC,1,1,DRAW
+2024,2025-04-05,31,Crystal Palace FC,Brighton & Hove Albion FC,2,1,HOME_TEAM
+2024,2025-04-05,31,Ipswich Town FC,Wolverhampton Wanderers FC,1,2,AWAY_TEAM
+2024,2025-04-05,31,West Ham United FC,AFC Bournemouth,2,2,DRAW
+2024,2025-04-05,31,Aston Villa FC,Nottingham Forest FC,2,1,HOME_TEAM
+2024,2025-04-06,31,Brentford FC,Chelsea FC,0,0,DRAW
+2024,2025-04-06,31,Fulham FC,Liverpool FC,3,2,HOME_TEAM
+2024,2025-04-06,31,Tottenham Hotspur FC,Southampton FC,3,1,HOME_TEAM
+2024,2025-04-06,31,Manchester United FC,Manchester City FC,0,0,DRAW
+2024,2025-04-07,31,Leicester City FC,Newcastle United FC,0,3,AWAY_TEAM
+2024,2025-04-12,32,Manchester City FC,Crystal Palace FC,5,2,HOME_TEAM
+2024,2025-04-12,32,Brighton & Hove Albion FC,Leicester City FC,2,2,DRAW
+2024,2025-04-12,32,Nottingham Forest FC,Everton FC,0,1,AWAY_TEAM
+2024,2025-04-12,32,Southampton FC,Aston Villa FC,0,3,AWAY_TEAM
+2024,2025-04-12,32,Arsenal FC,Brentford FC,1,1,DRAW
+2024,2025-04-13,32,Chelsea FC,Ipswich Town FC,2,2,DRAW
+2024,2025-04-13,32,Liverpool FC,West Ham United FC,2,1,HOME_TEAM
+2024,2025-04-13,32,Wolverhampton Wanderers FC,Tottenham Hotspur FC,4,2,HOME_TEAM
+2024,2025-04-13,32,Newcastle United FC,Manchester United FC,4,1,HOME_TEAM
+2024,2025-04-14,32,AFC Bournemouth,Fulham FC,1,0,HOME_TEAM
+2024,2025-04-16,29,Newcastle United FC,Crystal Palace FC,5,0,HOME_TEAM
+2024,2025-04-19,33,Brentford FC,Brighton & Hove Albion FC,4,2,HOME_TEAM
+2024,2025-04-19,33,Crystal Palace FC,AFC Bournemouth,0,0,DRAW
+2024,2025-04-19,33,Everton FC,Manchester City FC,0,2,AWAY_TEAM
+2024,2025-04-19,33,West Ham United FC,Southampton FC,1,1,DRAW
+2024,2025-04-19,33,Aston Villa FC,Newcastle United FC,4,1,HOME_TEAM
+2024,2025-04-20,33,Fulham FC,Chelsea FC,1,2,AWAY_TEAM
+2024,2025-04-20,33,Ipswich Town FC,Arsenal FC,0,4,AWAY_TEAM
+2024,2025-04-20,33,Manchester United FC,Wolverhampton Wanderers FC,0,1,AWAY_TEAM
+2024,2025-04-20,33,Leicester City FC,Liverpool FC,0,1,AWAY_TEAM
+2024,2025-04-21,33,Tottenham Hotspur FC,Nottingham Forest FC,1,2,AWAY_TEAM
+2024,2025-04-22,34,Manchester City FC,Aston Villa FC,2,1,HOME_TEAM
+2024,2025-04-23,34,Arsenal FC,Crystal Palace FC,2,2,DRAW
+2024,2025-04-26,34,Chelsea FC,Everton FC,1,0,HOME_TEAM
+2024,2025-04-26,34,Brighton & Hove Albion FC,West Ham United FC,3,2,HOME_TEAM
+2024,2025-04-26,34,Newcastle United FC,Ipswich Town FC,3,0,HOME_TEAM
+2024,2025-04-26,34,Southampton FC,Fulham FC,1,2,AWAY_TEAM
+2024,2025-04-26,34,Wolverhampton Wanderers FC,Leicester City FC,3,0,HOME_TEAM
+2024,2025-04-27,34,AFC Bournemouth,Manchester United FC,1,1,DRAW
+2024,2025-04-27,34,Liverpool FC,Tottenham Hotspur FC,5,1,HOME_TEAM
+2024,2025-05-01,34,Nottingham Forest FC,Brentford FC,0,2,AWAY_TEAM
+2024,2025-05-02,35,Manchester City FC,Wolverhampton Wanderers FC,1,0,HOME_TEAM
+2024,2025-05-03,35,Aston Villa FC,Fulham FC,1,0,HOME_TEAM
+2024,2025-05-03,35,Everton FC,Ipswich Town FC,2,2,DRAW
+2024,2025-05-03,35,Leicester City FC,Southampton FC,2,1,HOME_TEAM
+2024,2025-05-03,35,Arsenal FC,AFC Bournemouth,1,2,AWAY_TEAM
+2024,2025-05-04,35,Brentford FC,Manchester United FC,4,3,HOME_TEAM
+2024,2025-05-04,35,Brighton & Hove Albion FC,Newcastle United FC,1,1,DRAW
+2024,2025-05-04,35,West Ham United FC,Tottenham Hotspur FC,1,1,DRAW
+2024,2025-05-04,35,Chelsea FC,Liverpool FC,3,1,HOME_TEAM
+2024,2025-05-05,35,Crystal Palace FC,Nottingham Forest FC,1,1,DRAW

--- a/match_stats/fetch_football_stats.py
+++ b/match_stats/fetch_football_stats.py
@@ -1,0 +1,129 @@
+from dotenv import load_dotenv
+import os
+import requests
+import pandas as pd
+import argparse
+from typing import List, Dict
+
+load_dotenv()
+API_TOKEN = os.getenv("API_TOKEN")
+HEADERS = {'X-Auth-Token': API_TOKEN}
+URL = 'https://api.football-data.org/v4/competitions/PL/matches'
+
+def fetch_matches_for_season(season: int) -> List[Dict]:
+    """
+    Fetch matches for a given season from the football-data.org API.
+    
+    Args:
+        season (int): The season year to fetch matches for.
+        
+    Returns:
+        List[Dict]: A list of match dictionaries.
+    """
+    url = f"{URL}?season={season}"
+    response = requests.get(url, headers=HEADERS)
+
+    if response.status_code != 200:
+        raise Exception(f"Error fetching data for {season}: {response.status_code} - {response.text}")
+    
+    data = response.json().get('matches', [])
+    # We query the API for all matches in a season
+    return [
+        {
+            "season": season,
+            "date": m["utcDate"][:10],
+            "matchday": m.get("matchday"),
+            "hometeam": m["homeTeam"]["name"],
+            "awayteam": m["awayTeam"]["name"],
+            "homeGoals": m["score"]["fullTime"]["home"],
+            "awayGoals": m["score"]["fullTime"]["away"],
+            "winner": m["score"]["winner"],
+        }
+        for m in data if m["status"] == "FINISHED" # Only include finished matches
+    ]
+
+def fetch_all_seasons(seasons: List[int]) -> pd.DataFrame:
+    """
+    Fetch matches for multiple seasons and return as a DataFrame.
+    
+    Args:
+        seasons (List[int]): A list of season years to fetch matches for.
+        
+    Returns:
+        pd.DataFrame: A DataFrame containing all matches for the given seasons.
+    """
+    all_matches = []
+    for year in seasons:
+        print(f"Fetching matches for season {year}...")
+        matches = fetch_matches_for_season(year)
+        all_matches.extend(matches)
+    
+    return pd.DataFrame(all_matches)
+
+
+def transform_data(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Transform the DataFrame to a team-level KPI summary per season.
+    
+    Args:
+        df (pd.DataFrame): The DataFrame to transform (match level data).
+        
+    Returns:
+        pd.DataFrame: The transformed DataFrame: aggregated team KPIs per season.
+    """
+    records = []
+    # For each match, create records for both home and away teams
+    for _, row in df.iterrows():
+        # Create a record for the home team
+        records.append({
+            "season": row["season"],
+            "team": row["hometeam"],
+            "played": 1,
+            "won": int(row["winner"] == "HOME_TEAM"),
+            "drawn": int(row["winner"] is None),
+            "lost": int(row["winner"] == "AWAY_TEAM"),
+            "goals for": row["homeGoals"],
+            "goals against": row["awayGoals"],
+        })
+        # Create a record for the away team
+        records.append({
+            "season": row["season"],
+            "team": row["awayteam"],
+            "played": 1,
+            "won": int(row["winner"] == "AWAY_TEAM"),
+            "drawn": int(row["winner"] is None),
+            "lost": int(row["winner"] == "HOME_TEAM"),
+            "goals for": row["awayGoals"],
+            "goals against": row["homeGoals"],
+        })
+
+    df_teams = pd.DataFrame(records)
+    # Aggregate the data to get team-level KPIs per season
+    df_summary = df_teams.groupby(["season", "team"], as_index=False).sum()
+    return df_summary
+
+def main(seasons: List[int]): 
+    """
+    Main function to fetch and save football match data.
+    
+    Args:
+        seasons (List[int]): A list of season years to fetch matches for.
+    """
+    df_raw = fetch_all_seasons(seasons)
+    df_teams = transform_data(df_raw)
+    # Save the DataFrame to a CSV file
+    df_teams.to_csv('match_team_stats.csv', index=False)
+    df_raw.to_csv('match_raw_data.csv', index=False)
+    print("Data saved to match_team_stats.csv and match_raw_data.csv")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch football match data for specified seasons.")
+    parser.add_argument(
+        '--seasons', 
+        type=int, 
+        nargs='+', 
+        default=[2023, 2024], 
+        help='List of seasons to fetch data for (default: 2023, 2024)')  # We dont have access to data prior to 2023 on this API subscription plan
+    args = parser.parse_args()
+    main(args.seasons)
+

--- a/match_team_stats.csv
+++ b/match_team_stats.csv
@@ -1,0 +1,41 @@
+season,team,played,won,drawn,lost,goals for,goals against
+2023,AFC Bournemouth,38,13,0,16,54,67
+2023,Arsenal FC,38,28,0,5,91,29
+2023,Aston Villa FC,38,20,0,10,76,61
+2023,Brentford FC,38,10,0,19,56,65
+2023,Brighton & Hove Albion FC,38,12,0,14,55,62
+2023,Burnley FC,38,5,0,24,41,78
+2023,Chelsea FC,38,18,0,11,77,63
+2023,Crystal Palace FC,38,13,0,15,57,58
+2023,Everton FC,38,13,0,16,40,51
+2023,Fulham FC,38,13,0,17,55,61
+2023,Liverpool FC,38,24,0,4,86,41
+2023,Luton Town FC,38,6,0,24,52,85
+2023,Manchester City FC,38,28,0,3,96,34
+2023,Manchester United FC,38,18,0,14,57,58
+2023,Newcastle United FC,38,18,0,14,85,62
+2023,Nottingham Forest FC,38,9,0,20,49,67
+2023,Sheffield United FC,38,3,0,28,35,104
+2023,Tottenham Hotspur FC,38,20,0,12,74,61
+2023,West Ham United FC,38,14,0,14,60,74
+2023,Wolverhampton Wanderers FC,38,13,0,18,50,65
+2024,AFC Bournemouth,35,14,0,10,55,42
+2024,Arsenal FC,35,18,0,4,64,31
+2024,Aston Villa FC,35,17,0,9,55,49
+2024,Brentford FC,35,15,0,13,62,53
+2024,Brighton & Hove Albion FC,35,13,0,9,57,56
+2024,Chelsea FC,35,18,0,8,62,41
+2024,Crystal Palace FC,35,11,0,11,44,48
+2024,Everton FC,35,8,0,12,36,43
+2024,Fulham FC,35,14,0,12,50,47
+2024,Ipswich Town FC,35,4,0,21,35,76
+2024,Leicester City FC,35,5,0,24,29,77
+2024,Liverpool FC,35,25,0,3,81,35
+2024,Manchester City FC,35,19,0,9,67,43
+2024,Manchester United FC,35,10,0,16,42,51
+2024,Newcastle United FC,35,19,0,10,66,45
+2024,Nottingham Forest FC,35,18,0,10,54,42
+2024,Southampton FC,35,2,0,28,26,82
+2024,Tottenham Hotspur FC,35,11,0,19,63,57
+2024,West Ham United FC,35,9,0,16,40,59
+2024,Wolverhampton Wanderers FC,35,12,0,18,51,62

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+requests
+python-dotenv
+pytest

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,168 @@
+import pytest
+from unittest.mock import patch, Mock
+from match_stats.fetch_football_stats import fetch_matches_for_season, fetch_all_seasons
+import pandas as pd
+
+sample_response = {
+    "matches": [
+        {
+            "utcDate": "2023-08-13T14:00:00Z",
+            "matchday": 1,
+            "homeTeam": {"name": "Team A"},
+            "awayTeam": {"name": "Team B"},
+            "score": {
+                "fullTime": {"home": 2, "away": 1},
+                "winner": "HOME_TEAM"
+            },
+            "status": "FINISHED"
+        },
+        {
+            "utcDate": "2023-08-14T14:00:00Z",
+            "matchday": 1,
+            "homeTeam": {"name": "Team C"},
+            "awayTeam": {"name": "Team D"},
+            "score": {
+                "fullTime": {"home": 0, "away": 0},
+                "winner": None
+            },
+            "status": "FINISHED"
+        }
+    ]
+}
+
+@patch("match_stats.fetch_football_stats.requests.get")
+def test_fetch_matches_for_season(mock_get):
+    # Mock response
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = sample_response
+    mock_get.return_value = mock_response
+
+    results = fetch_matches_for_season(2023)
+    
+    assert isinstance(results, list)
+    assert len(results) == 2
+
+    first = results[0]
+    assert first["season"] == 2023
+    assert first["hometeam"] == "Team A"
+    assert first["awayteam"] == "Team B"
+    assert first["homeGoals"] == 2
+    assert first["awayGoals"] == 1
+    assert first["winner"] == "HOME_TEAM"
+    assert first["date"] == "2023-08-13"
+
+    second = results[1]
+    assert second["winner"] is None
+    assert second["homeGoals"] == 0
+    assert second["awayGoals"] == 0
+
+@patch("match_stats.fetch_football_stats.fetch_matches_for_season")
+def test_fetch_all_seasons(mock_fetch):
+    mock_fetch.return_value = [
+        {
+            "season": 2023,
+            "date": "2023-08-13",
+            "matchday": 1,
+            "hometeam": "Team A",
+            "awayteam": "Team B",
+            "homeGoals": 2,
+            "awayGoals": 1,
+            "winner": "HOME_TEAM"
+        },
+        {
+            "season": 2023,
+            "date": "2023-08-14",
+            "matchday": 1,
+            "hometeam": "Team C",
+            "awayteam": "Team D",
+            "homeGoals": 0,
+            "awayGoals": 0,
+            "winner": None
+        }
+    ]
+
+    df = fetch_all_seasons([2023])
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[0] == 2
+    assert "hometeam" in df.columns
+    assert df.loc[0, "hometeam"] == "Team A"
+    assert df.loc[1, "awayGoals"] == 0
+
+def test_transform_data():
+    # Sample input: 4 matches across 2 seasons (6 total team-season rows expected)
+    df = pd.DataFrame([
+        # Season 2023
+        {
+            "season": 2023,
+            "date": "2023-08-13",
+            "matchday": 1,
+            "hometeam": "Team A",
+            "awayteam": "Team B",
+            "homeGoals": 3,
+            "awayGoals": 1,
+            "winner": "HOME_TEAM"
+        },
+        {
+            "season": 2023,
+            "date": "2023-08-14",
+            "matchday": 2,
+            "hometeam": "Team B",
+            "awayteam": "Team C",
+            "homeGoals": 0,
+            "awayGoals": 0,
+            "winner": None
+        },
+        # Season 2024
+        {
+            "season": 2024,
+            "date": "2024-08-13",
+            "matchday": 1,
+            "hometeam": "Team A",
+            "awayteam": "Team C",
+            "homeGoals": 1,
+            "awayGoals": 2,
+            "winner": "AWAY_TEAM"
+        },
+        {
+            "season": 2024,
+            "date": "2024-08-14",
+            "matchday": 2,
+            "hometeam": "Team B",
+            "awayteam": "Team A",
+            "homeGoals": 0,
+            "awayGoals": 1,
+            "winner": "AWAY_TEAM"
+        }
+    ])
+
+    from match_stats.fetch_football_stats import transform_data
+    df_kpi = transform_data(df)
+
+    assert isinstance(df_kpi, pd.DataFrame)
+    assert set(["season", "team", "played", "won", "drawn", "lost", "goals for", "goals against"]).issubset(df_kpi.columns)
+    assert df_kpi.shape[0] == 6  # 4 matches = 8 team appearances grouped into 6 season-team entries
+
+    # Check Team A in 2023: played 1, won 1
+    team_a_2023 = df_kpi[(df_kpi["season"] == 2023) & (df_kpi["team"] == "Team A")].iloc[0]
+    assert team_a_2023["played"] == 1
+    assert team_a_2023["won"] == 1
+    assert team_a_2023["goals for"] == 3
+    assert team_a_2023["goals against"] == 1
+
+    # Check Team A in 2024: played 2, lost 1, won 1
+    team_a_2024 = df_kpi[(df_kpi["season"] == 2024) & (df_kpi["team"] == "Team A")].iloc[0]
+    assert team_a_2024["played"] == 2
+    assert team_a_2024["won"] == 1
+    assert team_a_2024["lost"] == 1
+    assert team_a_2024["goals for"] == 2
+    assert team_a_2024["goals against"] == 2
+
+    # Check Team C in 2024: played 1, won 1
+    team_c_2024 = df_kpi[(df_kpi["season"] == 2024) & (df_kpi["team"] == "Team C")].iloc[0]
+    assert team_c_2024["played"] == 1
+    assert team_c_2024["won"] == 1
+    assert team_c_2024["goals for"] == 2
+    assert team_c_2024["goals against"] == 1
+


### PR DESCRIPTION
This submission includes:

- Python script to fetch EPL match data (2023–2024) from football-data.org  
- Aggregation of key KPIs: played, won, drawn, lost, goals for, goals against (per season and team)  
- CLI support to pass season list (default: 2023, 2024)  
- Unit tests with pytest and mock coverage  
- Output files:
    - match_raw_data.csv
    - match_team_stats.csv  
- Dependencies: .env.example, requirements.txt, .gitignore included